### PR TITLE
[Documentation] Issue テンプレートの導入

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,59 @@
+name: 🐞 Bug
+description: 改善に役立つレポートを作成する
+title: "[Bug]: "
+labels: [bug]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      2. With this config...
+      3. Run '...'
+      4. See error...
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      examples:
+        - **OS**: Ubuntu 20.04
+        - **Node**: 13.14.0
+        - **npm**: 7.6.3
+    value: |
+        - OS:
+        - Node:
+        - npm:
+    render: markdown
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Links? References? Anything that will give us more context about the issue you are encountering!
+
+      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,6 +1,6 @@
 name: 🐞 Bug
 description: 改善に役立つレポートを作成する
-title: "[Bug]: "
+title: "<title>"
 labels: [bug]
 body:
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,29 @@
+name: Feature
+description: プロジェクトのアイデアを提案する
+title: "<title>"
+labels: [enhancement]
+body:
+- type: textarea
+  attributes:
+    label: Related to a problem
+    description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Solution
+    description: A clear and concise description of what you want to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Alternatives
+    description: A clear and concise description of any alternative solutions or features you've considered.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Additional context
+    description: Add any other context or screenshots about the feature request here.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/task-template.yaml
+++ b/.github/ISSUE_TEMPLATE/task-template.yaml
@@ -1,0 +1,21 @@
+name: Task
+description: タスクのテンプレートを記載する
+title: "<title>"
+body:
+- type: textarea
+  attributes:
+    label: Purpose
+    description: A concise description of what purpose the task is.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Todo list
+    description: A concise description of how can we close the issue.
+    value: |
+        - [ ] Sub task A
+        - [ ] Sub task B
+        - [ ] Sub task C
+    render: markdown
+  validations:
+    required: true


### PR DESCRIPTION
Closes #6 

■やったこと
- GitHub Issue Form を利用したテンプレートを追加
  - バグレポート
  - 機能リクエスト
  - タスクテンプレート